### PR TITLE
Add Helm chart

### DIFF
--- a/k8s/helm/banterop/Chart.yaml
+++ b/k8s/helm/banterop/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: banterop
+description: A Helm chart for Banterop application
+type: application
+version: 0.1.0
+appVersion: "main"
+home: https://github.com/jmandel/banterop
+sources:
+  - https://github.com/jmandel/banterop

--- a/k8s/helm/banterop/templates/deployment.yaml
+++ b/k8s/helm/banterop/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: banterop-api
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: banterop-api
+  template:
+    metadata:
+      labels:
+        app: banterop-api
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: api
+          image: {{ .Values.banterop.image | quote }}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+              name: http
+          volumeMounts: {{ toJson .Values.banterop.volumeMounts }}
+          env:
+          {{- range $configKey, $configValue := .Values.banterop.config }}
+            - name: {{ $configKey }}
+              value: {{ $configValue | quote }}
+          {{- end }}
+          {{- range $configKey, $configValue := .Values.banterop.secretConfig }}
+            - name: {{ $configKey }}
+              valueFrom:
+                secretKeyRef:
+                  name: banterop-secrets
+                  key: {{ $configKey }}
+          {{- end }}
+          resources:
+            requests: {{ toJson .Values.banterop.resources.requests }}
+            limits: {{ toJson .Values.banterop.resources.limits }}
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes: {{ toJson .Values.banterop.volumes }}
+      imagePullSecrets: {{ toJson .Values.banterop.imagePullSecrets }}
+      tolerations: {{ toJson .Values.banterop.tolerations }}
+      affinity: {{ toJson .Values.banterop.affinity }}

--- a/k8s/helm/banterop/templates/pvc.yaml
+++ b/k8s/helm/banterop/templates/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: banterop-db
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: {{ .Values.banterop.storageClassName }}

--- a/k8s/helm/banterop/templates/secret.yaml
+++ b/k8s/helm/banterop/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: banterop-secrets
+data:
+  {{- range $configKey, $configValue := .Values.banterop.secretConfig }}
+  {{ $configKey }}: {{ $configValue | b64enc }}
+  {{- end }}

--- a/k8s/helm/banterop/templates/service.yaml
+++ b/k8s/helm/banterop/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: banterop-api
+spec:
+  selector:
+    app: banterop-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/k8s/helm/banterop/values.yaml
+++ b/k8s/helm/banterop/values.yaml
@@ -1,0 +1,31 @@
+banterop:
+  image: ghcr.io/jmandel/banterop:main
+  volumeMounts:
+    - name: data
+      mountPath: /data
+    - name: public
+      mountPath: /app/public
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: banterop-db
+    - name: public
+      emptyDir: {}
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "2Gi"
+      cpu: "1000m"
+  storageClassName: ""
+  config:
+    PORT: "3000"
+    BANTEROP_DB: "/data/banterop.db"
+    DEFAULT_LLM_PROVIDER: "openrouter"
+    DEFAULT_LLM_MODEL: "gpt-oss-120b:nitro"
+    BASE_URL: "https://banterop.fhir.me"
+    BANTEROP_EVENTS_MAX: "5000"
+  secretConfig: {}
+  # secretConfig:
+  #   OPENROUTER_API_KEY: "[your-key]"


### PR DESCRIPTION
This change introduces a Helm chart for deploying Banterop to Kubernetes environments, providing a standardised and configurable deployment method.

The chart includes templated resources for deployment, service, persistent volume claim, and secret management. Resource definitions support customisable CPU and memory limits, storage class selection, and flexible volume mounting. Configuration is externalised through values.yaml, enabling environment-specific settings without modifying the base templates.

Ingress configuration is deliberately excluded from the chart as ingress requirements vary significantly between deployments and some environments may not require ingress resources at all. Users should create their own ingress resources as needed for their specific infrastructure and routing requirements.
