### PR TITLE
Fix literal \n escape sequences in markdown rendering

### DIFF
--- a/src/frontend/components/Markdown.tsx
+++ b/src/frontend/components/Markdown.tsx
@@ -21,10 +21,20 @@ function ensureLinksOpenInNewTab(html: string): string {
 
 export function Markdown({ text, className }:{ text?: string; className?: string }) {
   const html = React.useMemo(() => {
+    // Convert literal \n escape sequences to actual newlines before parsing.
+    const normalized = String(text ?? '').replace(/\\n/g, '\n');
+
     try {
-      const raw = marked.parse(String(text ?? '')) as string;
+      const raw = marked.parse(normalized) as string;
       return ensureLinksOpenInNewTab(raw);
-    } catch { return String(text ?? ''); }
+    } catch {
+      // Fallback: escape HTML and preserve newlines.
+      return normalized
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/\n/g, '<br>');
+    }
   }, [text]);
   return <div className={className || 'markdown'} dangerouslySetInnerHTML={{ __html: html }} />;
 }


### PR DESCRIPTION
## Summary
Fixes an issue where LLM responses were rendering literal `\n` escape sequences instead of actual line breaks.

## Problem
When displaying responses from LLM providers, newlines were appearing as literal `\n` characters in the UI rather than as actual line breaks. This occurred because double-encoded JSON strings from the server contained literal backslash-n sequences (`\n`) rather than actual newline characters.

## Solution
Modified the `Markdown` component to normalise text before parsing by converting literal `\n` escape sequences to actual newline characters. This ensures the `marked` library receives properly formatted text for parsing.

Changes made to `src/frontend/components/Markdown.tsx`:
- Added normalisation step to convert `\\n` to `\n` before calling `marked.parse()`
- Improved the fallback handler to properly escape HTML and convert newlines to `<br>` tags when markdown parsing fails